### PR TITLE
feat: added ability to override where routes are registered on Fastify

### DIFF
--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -2,7 +2,7 @@ import type { DynamicModule, MiddlewareConsumer, NestModule, OnModuleInit, Provi
 import type { Auth } from 'better-auth'
 import type { FastifyInstance, FastifyReply as Reply, FastifyRequest as Request } from 'fastify'
 
-import type { AuthAsyncOptions, AuthModuleOptions } from './auth-types.ts'
+import type { AuthAsyncOptions, AuthModuleOptions, AuthOptions } from './auth-types.ts'
 import { Inject, Logger, Module } from '@nestjs/common'
 import { APP_FILTER, DiscoveryModule, DiscoveryService, HttpAdapterHost, MetadataScanner } from '@nestjs/core'
 import { createAuthMiddleware } from 'better-auth/api'
@@ -26,6 +26,7 @@ export class AuthModule implements NestModule, OnModuleInit {
   private logger = new Logger(AuthModule.name)
   constructor(
     @Inject(AUTH_INSTANCE_KEY) private readonly auth: Auth,
+    @Inject(AUTH_MODULE_OPTIONS_KEY) private readonly options: AuthOptions,
     @Inject(DiscoveryService)
     private discoveryService: DiscoveryService,
     @Inject(MetadataScanner)
@@ -56,7 +57,7 @@ export class AuthModule implements NestModule, OnModuleInit {
   }
 
   configure(_: MiddlewareConsumer): void {
-    let basePath = this.auth.options.basePath ?? '/api/auth'
+    let basePath = this.options.basePath ?? this.auth.options.basePath ?? '/api/auth'
 
     // Ensure the basePath starts with / and doesn't end with /
     if (!basePath.startsWith('/')) {

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -26,7 +26,7 @@ export class AuthModule implements NestModule, OnModuleInit {
   private logger = new Logger(AuthModule.name)
   constructor(
     @Inject(AUTH_INSTANCE_KEY) private readonly auth: Auth,
-    @Inject(AUTH_MODULE_OPTIONS_KEY) private readonly options: AuthOptions,
+    @Inject(AUTH_MODULE_OPTIONS_KEY) private readonly options: AuthOptions | undefined,
     @Inject(DiscoveryService)
     private discoveryService: DiscoveryService,
     @Inject(MetadataScanner)
@@ -57,7 +57,7 @@ export class AuthModule implements NestModule, OnModuleInit {
   }
 
   configure(_: MiddlewareConsumer): void {
-    let basePath = this.options.basePath ?? this.auth.options.basePath ?? '/api/auth'
+    let basePath = this.options?.basePath ?? this.auth.options.basePath ?? '/api/auth'
 
     // Ensure the basePath starts with / and doesn't end with /
     if (!basePath.startsWith('/')) {

--- a/src/auth-types.ts
+++ b/src/auth-types.ts
@@ -35,8 +35,13 @@ export type SocketWithUserSession = Socket & {
   session: UserSession | null
 }
 
-interface AuthOptions {
+export interface AuthOptions {
   disableExceptionFilter?: boolean
+  /**
+   * Base path to register routes on. If not set, the Better Auth config value is used.
+   * This does not affect URL generation/redirect, or other features of Better Auth.
+   */
+  basePath?: string
   // disableTrustedOriginsCors?: boolean
   // disableBodyParser?: boolean
 }


### PR DESCRIPTION
Adds the ability to override where the Better Auth routes are registered on Fastify, without affecting the Better Auth library itself. Useful if you have any kind of URL re-writing happening between the public network and Fastify.

Order of priority for the base path is:

1. The override set in `basePath` of the AuthOptions passed into `forRoot`/`forRootAsync`
2. The value set in the Better Auth instance
3. `/api/auth`

This does not change existing functionality, it only extends by adding the #&#8203;1 override (#&#8203;2 and #&#8203;3 are current functionality).

Fixes #1 